### PR TITLE
Update uWebSocket for sifrr

### DIFF
--- a/javascript/sifrr/package.json
+++ b/javascript/sifrr/package.json
@@ -2,6 +2,6 @@
   "dependencies": {
     "@sifrr/server": "~0.0.6",
     "graphql": "*",
-    "uWebSockets.js": "uNetworking/uWebSockets.js#v17.4.0"
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v19.5.0"
   }
 }


### PR DESCRIPTION
The idea is to have the same version of engine (when version is managed outside of the framework)